### PR TITLE
remove the return at the end of the testing function

### DIFF
--- a/tests/test_stretch.py
+++ b/tests/test_stretch.py
@@ -23,6 +23,4 @@ def test_sampler_stretch():
     sampler.run(state_init)
 
     std = np.std(sampler.samples, axis=0)
-    print(f"Standard deviation of samples: {std}")
     assert np.all(std < 1.2), f"Standard deviation out of bounds: {std}"
-    return sampler.samples


### PR DESCRIPTION
I removed the return at the end of the testing function, test_sampler_stretch(), in the test_stretch.py file. Now this function should be compatible with pytest format. 