### PR TITLE
potential fix to read the docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,6 +12,16 @@ build:
     - asdf install uv latest
     - asdf global uv latest
     - uv venv
-    - uv pip install .[docs]
+    - uv pip install .[docs] --no-deps
+    - uv pip install sphinx>=7.0
+    - uv pip install myst_parser>=0.13
+    - uv pip install sphinx_copybutton
+    - uv pip install sphinx_autodoc_typehints
+    - uv pip install furo>=2023.08.17
+    - uv pip install nbsphinx
+    - uv pip install matplotlib
+    - uv pip install ipython
+    - uv pip install nbconvert
+    - uv pip install sphinx_gallery
     - .venv/bin/python -m sphinx -T -b html -d docs/_build/doctrees -D
       language=en docs $READTHEDOCS_OUTPUT/html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,6 +29,7 @@ exclude_patterns = [
     ".venv",
 ]
 
+autodoc_mock_imports = ["mpi4py"]
 
 html_theme = "furo"
 html_logo = "images/mchammer.png"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,6 @@ docs = [
   "nbconvert",
   "sphinx_gallery",
 ]
-autodoc_mock_imports = ["mpi4py"]
 
 [project.urls]
 Homepage = "https://github.com/zandalman/mchammers"


### PR DESCRIPTION
This pull request includes changes to the documentation build process and configuration files to improve the setup and functionality of the documentation environment.

### Documentation Build Process:
* Updated `.readthedocs.yaml` to install additional dependencies for building the documentation, such as `sphinx`, `myst_parser`, `sphinx_copybutton`, `sphinx_autodoc_typehints`, `furo`, `nbsphinx`, `matplotlib`, `ipython`, `nbconvert`, and `sphinx_gallery`. These changes ensure that all necessary packages are available for generating the documentation.

### Configuration Files:
* Added `autodoc_mock_imports` to `docs/conf.py` to mock the `mpi4py` import during the documentation build process. This prevents issues when the module is not available in the documentation environment.
* Removed `autodoc_mock_imports` from `pyproject.toml` as it is now included in `docs/conf.py`. This change centralizes the configuration related to mocking imports in the appropriate file.